### PR TITLE
BUG: Fix for nginx error -  for no host in ":80"

### DIFF
--- a/server/conf/nginx_vhost.conf.master
+++ b/server/conf/nginx_vhost.conf.master
@@ -1,5 +1,10 @@
 server {
+<tmpl_if name='ip_address'>
         listen <tmpl_var name='ip_address'>:80;
+</tmpl_else>
+        listen 80;
+</tmpl_if>
+
 <tmpl_if name='ipv6_enabled'>
         listen [<tmpl_var name='ipv6_address'>]:80;
 </tmpl_if>


### PR DESCRIPTION
When there is no IP address defined for server config it produces the following error that nginx doesn't like
[emerg] 16009#0: no host in ":80" of the "listen" directive in /etc/nginx/sites-enabled/100-blah.com.vhost:2

The template has been updated so that it doesn't generate a malformed nginx vhost configuration file.
